### PR TITLE
Add \norm and \normsq macros

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -289,6 +289,8 @@
 \providecommand{\mselr}[1]{\text{MSE}\paren{#1}}
 \providecommand{\maelr}[1]{\text{MAE}\paren{#1}}
 \providecommand{\abs}[1]{\left|#1\right|}
+\providecommand{\norm}[1]{\left\lVert#1\right\rVert}
+\providecommand{\normsq}[1]{\left\lVert#1\right\rVert^2}
 \providecommand{\sqf}[1]{\paren{#1}^2}
 \providecommand{\sq}{^2}
 \def\err{\eps}


### PR DESCRIPTION
Adds two vector/matrix norm helper macros to `macros.qmd`, consistent with the existing `\abs` pattern.

## Changes

- `\norm{v}` → `\left\lVert v \right\rVert`
- `\normsq{v}` → `\left\lVert v \right\rVert^2`

Requested from `d-morrison/rme` to support norm notation in course materials.