### PR TITLE
Add residual macros: resid, stdresid, modresid, residv

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -419,3 +419,7 @@
 \def\signt{\text{sign}}
 \providecommand{\signf}[1]{\signt\cb{#1}}
 \def\reals{\mathbb{R}}
+\def\resid{r}
+\def\stdresid{r'}
+\def\modresid{r^*}
+\providecommand{\residv}{\vec{r}}


### PR DESCRIPTION
Adds `\def\resid{r}`, `\def\stdresid{r'}`, `\def\modresid{r^*}`, and `\providecommand{\residv}{\vec{r}}` macros needed by `rme` (d-morrison/rme).