### PR TITLE
Update macros documentation

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -366,6 +366,8 @@ name	interpretation
 \prodin	product over i from 1 to n
 \prodi1n	product over i from 1 to n (alias)
 \lp	linear predictor x′β
+\lpdp	linear predictor at x (dot product x⃗·β⃗)
+\lincomp	linear combination symbol η
 \odds	odds symbol ω
 \OR	odds ratio label OR
 \ror	ratio of odds (odds ratio) θ

--- a/macros.qmd
+++ b/macros.qmd
@@ -364,14 +364,13 @@
 \def\prodin{\prod_{i=1}^n}
 \def\prodi1n{\prod_{i=1}^n}
 \providecommand{\lp}[1]{\dprodf{#1}{\vb}}
-\def\lpdp{\lp{\vx}{\vb}}
+\def\lpdp{\lp{\vx}}
 \def\lincomp{\eta}
 \def\odds{\omega}
 \def\OR{\operatorname{OR}}
 \def\ror{\theta}
 \def\logodds{\lincomp}
 \providecommand{\logoddsf}[1]{\logodds \paren{#1}}
-\def\diff{\Delta}
 \def\difflogodds{\diff \logodds}
 \def\hdifflogodds{\widehat{\difflogodds}}
 \def\diffeta{\diff \eta}

--- a/macros.qmd
+++ b/macros.qmd
@@ -363,15 +363,18 @@
 \def\sumi1n{\sum_{i=1}^n}
 \def\prodin{\prod_{i=1}^n}
 \def\prodi1n{\prod_{i=1}^n}
-\providecommand{\lp}[2]{#1 \' \beta}
+\providecommand{\lp}[1]{\dprodf{#1}{\vb}}
+\def\lpdp{\lp{\vx}{\vb}}
+\def\lincomp{\eta}
 \def\odds{\omega}
 \def\OR{\operatorname{OR}}
 \def\ror{\theta}
-\def\logodds{\eta}
+\def\logodds{\lincomp}
 \providecommand{\logoddsf}[1]{\logodds \paren{#1}}
-\def\difflogodds{\Delta \eta}
-\def\hdifflogodds{\widehat{\Delta \eta}}
-\def\diffeta{\Delta \eta}
+\def\diff{\Delta}
+\def\difflogodds{\diff \logodds}
+\def\hdifflogodds{\widehat{\difflogodds}}
+\def\diffeta{\diff \eta}
 \def\oddst{\operatorname{odds}}
 \def\probst{\operatorname{probs}}
 \def\probt{\operatorname{prob}}
@@ -392,8 +395,8 @@
 \def\hazratio{\theta}
 \def\hr{\theta}
 \providecommand{\hrf}[1]{\theta\paren{#1}}
-\def\loghaz{\eta}
-\def\diffloghaz{\Delta \eta}
+\def\loghaz{\lincomp}
+\def\diffloghaz{\diff \loghaz}
 \def\cuhaz{{\Lambda}}
 \def\cumhaz{\cuhaz}
 \def\Surv{\surv}


### PR DESCRIPTION
This pull request updates several macro definitions in `macros.qmd` to improve consistency and clarity of notation, especially for linear combinations and log-odds/log-hazard expressions. The changes mainly standardize the use of the linear combination symbol and its related macros, and introduce a new general difference macro.

**Standardization and refactoring of macros:**

* Changed the `\lp` macro to take only one argument and use the new `\dprodf` macro for linear combinations, and updated related definitions (`\lpdp`, `\lincomp`).
* Updated the definition of `\logodds` and `\loghaz` to use the new `\lincomp` macro, ensuring consistent notation for linear predictors. [[1]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bL366-R377) [[2]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bL395-R399)

**Generalization of difference notation:**

* Introduced a new macro `\diff` for generic differences, and refactored `\difflogodds`, `\hdifflogodds`, `\diffeta`, and `\diffloghaz` to use this new macro for improved clarity and consistency. [[1]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bL366-R377) [[2]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bL395-R399)

These changes help make the macro definitions more modular and consistent throughout the codebase.