### PR TITLE
Update macros in documentation

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -68,6 +68,8 @@ name	interpretation
 \gl	Greek letter lambda (alias for \l)
 \lam	Greek letter lambda (alias for \l)
 \k	Greek letter kappa (κ)
+\cs	conditional survival probability Pr(T>t|T≥t)
+\condsurv	conditional survival probability (alias for \cs)
 \gs	Greek letter sigma (alias for \s)
 \gm	Greek letter mu (alias for \m)
 \M	uppercase M symbol (italic variable, alias for mean/moment)

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -67,6 +67,7 @@ name	interpretation
 \l	Greek letter lambda (λ)
 \gl	Greek letter lambda (alias for \l)
 \lam	Greek letter lambda (alias for \l)
+\k	Greek letter kappa (κ)
 \gs	Greek letter sigma (alias for \s)
 \gm	Greek letter mu (alias for \m)
 \M	uppercase M symbol (italic variable, alias for mean/moment)
@@ -79,6 +80,8 @@ name	interpretation
 \defeq	equals-by-definition (alias for \eqdef)
 \hb	estimated beta coefficient β̂
 \hvb	estimated beta vector (β̂-vector)
+\hk	estimated kappa κ̂
+\hkappa	estimated kappa (alias for \hk)
 \hl	estimated lambda λ̂
 \hy	fitted / predicted value ŷ
 \yh	fitted value ŷ (alias for \hy)

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -392,6 +392,7 @@ name	interpretation
 \doddsinvf	derivative of inverse odds function
 \dinvoddsf	derivative of inverse odds (alias)
 \rate	rate / hazard symbol λ
+\lograte	log-rate symbol η
 \haz	hazard function symbol λ (alias for \rate)
 \hazratio	hazard ratio symbol θ
 \hr	hazard ratio (alias for \hazratio)

--- a/macros.qmd
+++ b/macros.qmd
@@ -67,6 +67,8 @@
 \def\gl{\lambda}
 \def\lam{\lambda}
 \def\k{\kappa}
+\def\cs{\kappa}
+\def\condsurv{\kappa}
 \def\gs{\sigma}
 \def\gm{\mu}
 \def\M{M}

--- a/macros.qmd
+++ b/macros.qmd
@@ -66,6 +66,7 @@
 \def\l{\lambda}
 \def\gl{\lambda}
 \def\lam{\lambda}
+\def\k{\kappa}
 \def\gs{\sigma}
 \def\gm{\mu}
 \def\M{M}
@@ -78,6 +79,8 @@
 \def\defeq{\stackrel{\text{def}}{=}}
 \def\hb{\hat \beta}
 \def\hvb{\hat{\vb}}
+\def\hk{\hat \kappa}
+\def\hkappa{\hat \kappa}
 \def\hl{\hat \lambda}
 \def\hy{\hat y}
 \def\yh{\hat y}

--- a/macros.qmd
+++ b/macros.qmd
@@ -390,6 +390,7 @@
 \providecommand{\doddsinvf}[1]{{\oddsinv}'\cb{#1}}
 \providecommand{\dinvoddsf}[1]{{\invodds}'\cb{#1}}
 \def\rate{{\lambda}}
+% NOTE: keep interpretations.tsv in sync with new macro names; \lograte needs a matching interpretation row.
 \def\lograte{\lincomp}
 \def\haz{{\lambda}}
 \def\hazratio{\theta}

--- a/macros.qmd
+++ b/macros.qmd
@@ -390,6 +390,7 @@
 \providecommand{\doddsinvf}[1]{{\oddsinv}'\cb{#1}}
 \providecommand{\dinvoddsf}[1]{{\invodds}'\cb{#1}}
 \def\rate{{\lambda}}
+\def\lograte{\lincomp}
 \def\haz{{\lambda}}
 \def\hazratio{\theta}
 \def\hr{\theta}

--- a/macros.qmd
+++ b/macros.qmd
@@ -393,7 +393,6 @@
 \providecommand{\doddsinvf}[1]{{\oddsinv}'\cb{#1}}
 \providecommand{\dinvoddsf}[1]{{\invodds}'\cb{#1}}
 \def\rate{{\lambda}}
-% NOTE: keep interpretations.tsv in sync with new macro names; \lograte needs a matching interpretation row.
 \def\lograte{\lincomp}
 \def\haz{{\lambda}}
 \def\hazratio{\theta}


### PR DESCRIPTION
This pull request introduces a new macro definition to the `macros.qmd` file. The main change is the addition of a shorthand macro for the log-rate parameter, improving code clarity and consistency.

Macro additions:

* Added a new macro definition `\lograte` as an alias for `\lincomp`, which can now be used in place of writing `\lincomp` directly.