### PR TITLE
Define conditional survival macro

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -391,6 +391,7 @@
 \providecommand{\dinvoddsf}[1]{{\invodds}'\cb{#1}}
 \def\rate{{\lambda}}
 \def\haz{{\lambda}}
+\def\cs{{\kappa}}
 \def\hazratio{\theta}
 \def\hr{\theta}
 \providecommand{\hrf}[1]{\theta\paren{#1}}


### PR DESCRIPTION
## Summary
- add a \cs macro for conditional survival notation, currently rendered as \kappa

## Testing
- not run; macro-only change