### PR TITLE
Define color macros with \textcolor to silence pandoc math warnings

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -177,7 +177,6 @@
 \providecommand{\xderiv}[2]{\frac{\partial^2}{\partial #1 \partial #2}}
 \providecommand{\xderivf}[3]{\frac{\partial^2 #1}{\partial #2 \partial #3}}
 \providecommand{\xderivff}[3]{\frac{\partial^2 #3}{\partial #1 \partial #2}}
-<!-- https://www.overleaf.com/learn/latex/Using_colors_in_LaTeX#Named_colors_provided_by_the_xcolor_package -->
 \providecommand{\red}[1]{\textcolor{red}{#1}}
 \providecommand{\green}[1]{\textcolor{green}{#1}}
 \providecommand{\blue}[1]{\textcolor{blue}{#1}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -171,25 +171,25 @@
 \providecommand{\xderivf}[3]{\frac{\partial^2 #1}{\partial #2 \partial #3}}
 \providecommand{\xderivff}[3]{\frac{\partial^2 #3}{\partial #1 \partial #2}}
 <!-- https://www.overleaf.com/learn/latex/Using_colors_in_LaTeX#Named_colors_provided_by_the_xcolor_package -->
-\providecommand{\red}[1]{{\color{red}#1}}
-\providecommand{\green}[1]{{\color{green}#1}}
-\providecommand{\blue}[1]{{\color{blue}#1}}
-\providecommand{\cyan}[1]{{\color{cyan}#1}}
-\providecommand{\magenta}[1]{{\color{magenta}#1}}
-\providecommand{\yellow}[1]{{\color{yellow}#1}}
-\providecommand{\black}[1]{{\color{black}#1}}
-\providecommand{\gray}[1]{{\color{gray}#1}}
-\providecommand{\white}[1]{{\color{white}#1}}
-\providecommand{\darkgray}[1]{{\color{darkgray}#1}}
-\providecommand{\lightgray}[1]{{\color{lightgray}#1}}
-\providecommand{\brown}[1]{{\color{brown}#1}}
-\providecommand{\lime}[1]{{\color{lime}#1}}
-\providecommand{\olive}[1]{{\color{olive}#1}}
-\providecommand{\orange}[1]{{\color{orange}#1}}
-\providecommand{\pink}[1]{{\color{pink}#1}}
-\providecommand{\purple}[1]{{\color{purple}#1}}
-\providecommand{\teal}[1]{{\color{teal}#1}}
-\providecommand{\violet}[1]{{\color{violet}#1}}
+\providecommand{\red}[1]{\textcolor{red}{#1}}
+\providecommand{\green}[1]{\textcolor{green}{#1}}
+\providecommand{\blue}[1]{\textcolor{blue}{#1}}
+\providecommand{\cyan}[1]{\textcolor{cyan}{#1}}
+\providecommand{\magenta}[1]{\textcolor{magenta}{#1}}
+\providecommand{\yellow}[1]{\textcolor{yellow}{#1}}
+\providecommand{\black}[1]{\textcolor{black}{#1}}
+\providecommand{\gray}[1]{\textcolor{gray}{#1}}
+\providecommand{\white}[1]{\textcolor{white}{#1}}
+\providecommand{\darkgray}[1]{\textcolor{darkgray}{#1}}
+\providecommand{\lightgray}[1]{\textcolor{lightgray}{#1}}
+\providecommand{\brown}[1]{\textcolor{brown}{#1}}
+\providecommand{\lime}[1]{\textcolor{lime}{#1}}
+\providecommand{\olive}[1]{\textcolor{olive}{#1}}
+\providecommand{\orange}[1]{\textcolor{orange}{#1}}
+\providecommand{\pink}[1]{\textcolor{pink}{#1}}
+\providecommand{\purple}[1]{\textcolor{purple}{#1}}
+\providecommand{\teal}[1]{\textcolor{teal}{#1}}
+\providecommand{\violet}[1]{\textcolor{violet}{#1}}
 \providecommand{\hE}[1]{\hat{\text{E}}\sb{#1}}
 \providecommand{\hExp}[1]{\hat{\text{E}}\sb{#1}}
 \providecommand{\hExpf}[1]{\hat{\text{E}}\sb{#1}}


### PR DESCRIPTION
## Summary

The color macros (`\red`, `\blue`, `\green`, ...) were defined with plain-TeX color scoping:

```tex
\providecommand{\red}[1]{{\color{red}#1}}
```

When used inside math like `\red{X_j = a}`, this expands to `{\color{red}X_j = a}`, which pandoc's math reader cannot parse. The result is a stream of `[WARNING] Could not convert TeX math` entries in build logs across every consuming repo (epi204, etc.) and degraded HTML/MathJax/KaTeX renders for those expressions.

Switched all 19 color macros to use `\textcolor{name}{#1}`, which is the standard xcolor form pandoc recognizes. PDF rendering is unaffected because both forms produce equivalent LaTeX output.

## Test plan

- [ ] Render a downstream doc that uses `\blue{...}` / `\red{...}` in math (e.g. epi204's `_exr-math-interp-beta-PV.qmd`) to PDF and confirm colors still render
- [ ] Confirm the `[WARNING] Could not convert TeX math` warnings for those expressions disappear from the build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)