### PR TITLE
feat: add \derivfnd and \derivfdn macros

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -181,6 +181,7 @@ name	interpretation
 \xderiv	cross partial derivative ∂²/∂x∂y
 \xderivf	cross partial ∂²f/∂x∂y with numerator
 \xderivff	cross partial (reversed argument order)
+\dif	total derivative fraction dF/dt (numerator first, denominator second)
 \red	typeset argument in red
 \green	typeset argument in green
 \blue	typeset argument in blue

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -175,8 +175,8 @@ name	interpretation
 \dderiv	second partial derivative ∂²/∂(·)²
 \derivf	partial derivative ∂f/∂x with numerator
 \derivff	partial derivative ∂f/∂x (reversed argument order)
-\derivfnd	partial derivative ∂f/∂x (numerator first, denominator second)
-\derivfdn	partial derivative ∂f/∂x (denominator first, numerator second)
+\derivfnd	alias for \derivf (numerator first, denominator second)
+\derivfdn	alias for \derivff (denominator first, numerator second)
 \dderivf	second partial derivative ∂²f/∂x²
 \xderiv	cross partial derivative ∂²/∂x∂y
 \xderivf	cross partial ∂²f/∂x∂y with numerator

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -175,6 +175,8 @@ name	interpretation
 \dderiv	second partial derivative ∂²/∂(·)²
 \derivf	partial derivative ∂f/∂x with numerator
 \derivff	partial derivative ∂f/∂x (reversed argument order)
+\derivfnd	partial derivative ∂f/∂x (numerator first, denominator second)
+\derivfdn	partial derivative ∂f/∂x (denominator first, numerator second)
 \dderivf	second partial derivative ∂²f/∂x²
 \xderiv	cross partial derivative ∂²/∂x∂y
 \xderivf	cross partial ∂²f/∂x∂y with numerator

--- a/macros.qmd
+++ b/macros.qmd
@@ -173,6 +173,8 @@
 \providecommand{\dderiv}[1]{\frac{\partial^2}{\partial #1^2}}
 \providecommand{\derivf}[2]{\frac{\partial #1}{\partial #2}}
 \providecommand{\derivff}[2]{\frac{\partial #2}{\partial #1}}
+\providecommand{\derivfnd}[2]{\frac{\partial #1}{\partial #2}}
+\providecommand{\derivfdn}[2]{\frac{\partial #2}{\partial #1}}
 \providecommand{\dderivf}[2]{\frac{\partial^2 #1}{\partial #2^2}}
 \providecommand{\xderiv}[2]{\frac{\partial^2}{\partial #1 \partial #2}}
 \providecommand{\xderivf}[3]{\frac{\partial^2 #1}{\partial #2 \partial #3}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -173,8 +173,8 @@
 \providecommand{\dderiv}[1]{\frac{\partial^2}{\partial #1^2}}
 \providecommand{\derivf}[2]{\frac{\partial #1}{\partial #2}}
 \providecommand{\derivff}[2]{\frac{\partial #2}{\partial #1}}
-\providecommand{\derivfnd}[2]{\frac{\partial #1}{\partial #2}}
-\providecommand{\derivfdn}[2]{\frac{\partial #2}{\partial #1}}
+\providecommand{\derivfnd}[2]{\derivf{#1}{#2}}
+\providecommand{\derivfdn}[2]{\derivff{#1}{#2}}
 \providecommand{\dderivf}[2]{\frac{\partial^2 #1}{\partial #2^2}}
 \providecommand{\xderiv}[2]{\frac{\partial^2}{\partial #1 \partial #2}}
 \providecommand{\xderivf}[3]{\frac{\partial^2 #1}{\partial #2 \partial #3}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -179,6 +179,7 @@
 \providecommand{\xderiv}[2]{\frac{\partial^2}{\partial #1 \partial #2}}
 \providecommand{\xderivf}[3]{\frac{\partial^2 #1}{\partial #2 \partial #3}}
 \providecommand{\xderivff}[3]{\frac{\partial^2 #3}{\partial #1 \partial #2}}
+\providecommand{\dif}[2]{\frac{d #1}{d #2}}
 \providecommand{\red}[1]{\textcolor{red}{#1}}
 \providecommand{\green}[1]{\textcolor{green}{#1}}
 \providecommand{\blue}[1]{\textcolor{blue}{#1}}


### PR DESCRIPTION
Adds `\derivfnd` and `\derivfdn` as variants of `\derivf` with explicit argument order naming:

- `\derivfnd`: numerator first, denominator second
- `\derivfdn`: denominator first, numerator second

Closes #45

Generated with [Claude Code](https://claude.ai/code)