### PR TITLE
feat: add \riskset and \risksetf macros for survival analysis risk set

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -27,6 +27,8 @@ name	interpretation
 \Sf	survival function S(·) applied to argument
 \surv	survival function symbol (alias for \S)
 \survf	survival function applied to argument (alias for \Sf)
+\riskset	risk set symbol ℛ (survival analysis)
+\risksetf	risk set at time t: ℛ(t)
 \ph	estimated probability p-hat
 \P	probability operator P
 \hp	estimated probability (alias for \ph)

--- a/macros.qmd
+++ b/macros.qmd
@@ -26,6 +26,8 @@
 \providecommand{\Sf}[1]{\S\paren{#1}}
 \def\surv{\distop{S}}
 \providecommand{\survf}[1]{\surv\paren{#1}}
+\def\riskset{\mathcal{R}}
+\providecommand{\risksetf}[1]{\riskset\paren{#1}}
 \def\ph{\mathop{\hat{\p}}\nolimits}
 \def\P{\distop{P}}
 \def\hp{\mathop{\hat{\p}}\nolimits}


### PR DESCRIPTION
Adds \riskset (\mathcal{R}) and \risksetf (function form \riskset(t)) for denoting the risk set in survival analysis contexts.

Closes #47

Generated with [Claude Code](https://claude.ai/code)