### PR TITLE
feat: add macros for quantile function

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -29,6 +29,14 @@ name	interpretation
 \survf	survival function applied to argument (alias for \Sf)
 \riskset	risk set symbol ℛ (survival analysis)
 \risksetf	risk set at time t: ℛ(t)
+\Q	quantile function symbol Q
+\quantile	quantile function symbol (alias for \Q)
+\Qf	quantile function Q(·) applied to argument
+\quantilef	quantile function applied to argument (alias for \Qf)
+\hQ	estimated quantile function Q̂
+\hquantile	estimated quantile function (alias for \hQ)
+\hQf	estimated quantile function Q̂(·) applied to argument
+\hquantilef	estimated quantile function applied to argument (alias for \hQf)
 \ph	estimated probability p-hat
 \P	probability operator P
 \hp	estimated probability (alias for \ph)

--- a/macros.qmd
+++ b/macros.qmd
@@ -28,6 +28,14 @@
 \providecommand{\survf}[1]{\surv\paren{#1}}
 \def\riskset{\mathcal{R}}
 \providecommand{\risksetf}[1]{\riskset\paren{#1}}
+\def\Q{\distop{Q}}
+\def\quantile{\distop{Q}}
+\providecommand{\Qf}[1]{\Q\paren{#1}}
+\providecommand{\quantilef}[1]{\quantile\paren{#1}}
+\def\hQ{\mathop{\hat{\Q}}\nolimits}
+\def\hquantile{\mathop{\hat{\quantile}}\nolimits}
+\providecommand{\hQf}[1]{\hQ\paren{#1}}
+\providecommand{\hquantilef}[1]{\hquantile\paren{#1}}
 \def\ph{\mathop{\hat{\p}}\nolimits}
 \def\P{\distop{P}}
 \def\hp{\mathop{\hat{\p}}\nolimits}


### PR DESCRIPTION
Adds macros for the quantile function (\Q) and estimated quantile function (\hQ), following existing patterns for distribution function operators.

Closes #49

Generated with [Claude Code](https://claude.ai/code)