### PR TITLE
Update macros.qmd

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -344,6 +344,8 @@ name	interpretation
 \vX	random vector X (X̃)
 \vy	outcome vector y (ỹ)
 \vY	uppercase outcome vector Y (Ỹ)
+\vz	vector z (z̃)
+\vZ	random vector Z (Z̃)
 \vD	exposure/treatment vector D (D̃)
 \vd	exposure vector d lowercase (d̃)
 \vT	time vector T (T̃)
@@ -448,3 +450,5 @@ name	interpretation
 \signt	sign operator symbol
 \signf	sign function sign{·}
 \reals	real numbers ℝ
+\ub	underbrace shorthand (alias for \underbrace)
+\ubf	underbrace with subscript label \underbrace{·}_{label}

--- a/macros.qmd
+++ b/macros.qmd
@@ -452,4 +452,6 @@
 \def\resid{r}
 \def\stdresid{r'}
 \def\modresid{r^*}
+\def\ub{\underbrace} % underbrace shorthand
+\providecommand{\ubf}[2]{\ub{#1}_{#2}} % underbrace with subscript label
 \providecommand{\residv}{\vec{r}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -342,8 +342,8 @@
 \def\vX{\vecf{X}}
 \def\vy{\vecf{y}}
 \def\vY{\vecf{Y}}
-\def\vz{\vecf{z}}
-\def\vZ{\vecf{Z}}
+\def\vz{\vecf{z}} % vector z
+\def\vZ{\vecf{Z}} % vector Z
 \def\vD{\vecf{D}}
 \def\vd{\vecf{d}}
 \def\vT{\vecf{T}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -342,8 +342,8 @@
 \def\vX{\vecf{X}}
 \def\vy{\vecf{y}}
 \def\vY{\vecf{Y}}
-\def\vz{\vecf{z}} % vector z
-\def\vZ{\vecf{Z}} % vector Z
+\def\vz{\vecf{z}}
+\def\vZ{\vecf{Z}}
 \def\vD{\vecf{D}}
 \def\vd{\vecf{d}}
 \def\vT{\vecf{T}}
@@ -452,6 +452,6 @@
 \def\resid{r}
 \def\stdresid{r'}
 \def\modresid{r^*}
-\def\ub{\underbrace} % underbrace shorthand
-\providecommand{\ubf}[2]{\ub{#1}_{#2}} % underbrace with subscript label
+\def\ub{\underbrace}
+\providecommand{\ubf}[2]{\ub{#1}_{#2}}
 \providecommand{\residv}{\vec{r}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -342,6 +342,8 @@
 \def\vX{\vecf{X}}
 \def\vy{\vecf{y}}
 \def\vY{\vecf{Y}}
+\def\vz{\vecf{z}}
+\def\vZ{\vecf{Z}}
 \def\vD{\vecf{D}}
 \def\vd{\vecf{d}}
 \def\vT{\vecf{T}}


### PR DESCRIPTION
This pull request adds new vector notation macros and underbrace shorthand commands to improve mathematical notation consistency and clarity. The main changes are grouped below:

**Vector notation additions:**

* Added definitions for `\vz` and `\vZ` as vector and random vector notations, respectively, in both `macros.qmd` and `interpretations.tsv`. [[1]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bR345-R346) [[2]](diffhunk://#diff-2d1ac86e339819e47226d73337cc42960ea72608066b729860fc1eb1ce47dd23R347-R348)

**Underbrace shorthand commands:**

* Introduced `\ub` as a shorthand for `\underbrace` and `\ubf` for labeled underbraces in both `macros.qmd` and `interpretations.tsv`. [[1]](diffhunk://#diff-41da372b502fd19e7a4e240d144e7bc6332fce445bb217400d11c850a9d69f8bR455-R456) [[2]](diffhunk://#diff-2d1ac86e339819e47226d73337cc42960ea72608066b729860fc1eb1ce47dd23R453-R454)