### PR TITLE
Add \NA macro for missing-value placeholder

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -488,6 +488,7 @@ name	interpretation
 \signt	sign operator symbol
 \signf	sign function sign{·}
 \reals	real numbers ℝ
+\NA	not-available / missing-value placeholder (text "NA")
 \ub	underbrace shorthand (alias for \underbrace)
 \ubf	underbrace with subscript label \underbrace{·}_{label}
 \factor	generic factor symbol θ (base for \hazfactor, \riskfactor, and similar factor macros; compares one covariate pattern to the baseline; subscript denotes the factor type)

--- a/macros.qmd
+++ b/macros.qmd
@@ -525,6 +525,7 @@
 \def\signt{\operatorname{sign}}
 \providecommand{\signf}[1]{\signt\cb{#1}}
 \def\reals{\mathbb{R}}
+\def\NA{\text{NA}}
 \def\resid{r}
 \def\stdresid{r'}
 \def\modresid{r^*}


### PR DESCRIPTION
## Summary

Adds `\def\NA{\text{NA}}` (rendering the literal "NA") plus its `interpretations.tsv` entry.

## Why

Downstream decks that consume this submodule write `\NA` to denote a missing/undefined value — e.g. UCD-SERG/serocalculator's methodology vignette uses it in the age-truncated exponential model:

$$\pdf(T=t|A=a) = 1_{t \in[0,a]} \,\lambda e^{-\lambda t} + 1_{t = \NA}\, e^{-\lambda a}$$

`\NA` is the only macro that deck needs which wasn't already in this submodule. Adding it here lets serocalculator (UCD-SERG/serocalculator#534) delete its local macros file and rely entirely on the shared set.

## Notes

- `macros.qmd` stays comment-free (per CONTRIBUTING.md).
- Added the matching `interpretations.tsv` row so the `macros-table.qmd` build doesn't fail on a missing interpretation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)