### PR TITLE
Silence pandoc texmath warnings in the include-in-header demo

### DIFF
--- a/demo-include-in-header.qmd
+++ b/demo-include-in-header.qmd
@@ -67,6 +67,54 @@ This inserts the macro definitions for each output format:
 
 The table below uses macros defined with `\def` in `macros.qmd`, which work in all output formats that support MathJax or LaTeX:
 
+```{r}
+#| label: register-macros-with-pandoc
+#| echo: false
+#| results: asis
+
+# Register the macros with pandoc's static math parser (texmath).
+#
+# The include-in-header strategy above loads macros into MathJax (HTML/RevealJS)
+# and the LaTeX preamble (PDF) at *render* time. pandoc's texmath pre-pass,
+# however, never sees them, so when it tries to convert the `$...$` examples
+# below it warns "Could not convert TeX math \a, ...". Pandoc's latex_macros
+# extension *does* pick up bare \def definitions placed in the document body and
+# apply them to subsequent math, so emitting the definitions once (hidden) here
+# silences the warnings. These bare \def lines are not `$...$` math, so MathJax
+# ignores them in the browser: the visible examples below still render via the
+# include-in-header config, not this block. It only satisfies pandoc's static
+# parser and is NOT part of the demonstrated include-in-header mechanism.
+#
+# Excluded from PDF, where display:none has no effect; PDF already resolves the
+# macros via the preamble (\providecommand and all).
+defs <- readLines("macros.qmd", warn = FALSE)
+defs <- defs[!grepl("^\\s*<!--", defs) & nzchar(trimws(defs))]
+
+# texmath/MathJax need \def, not \providecommand:
+# \providecommand{\name}[n]{body} -> \def\name#1...#n{body}.
+defs <- vapply(defs, function(line) {
+  m <- regmatches(
+    line,
+    regexec(
+      "^\\\\providecommand\\{\\\\([^}]+)\\}(?:\\[(\\d+)\\])?\\{(.*)\\}\\s*$",
+      line,
+      perl = TRUE
+    )
+  )[[1]]
+  if (length(m) == 4L && nzchar(m[1L])) {
+    nargs    <- if (nzchar(m[3L])) as.integer(m[3L]) else 0L
+    args_str <- if (nargs > 0L) paste0("#", seq_len(nargs), collapse = "") else ""
+    return(paste0("\\def\\", m[2L], args_str, "{", m[4L], "}"))
+  }
+  line
+}, character(1L), USE.NAMES = FALSE)
+
+cat(':::: {.content-hidden when-format="pdf"}\n')
+cat('::: {style="display:none"}\n')
+cat(paste(defs, collapse = "\n"), "\n")
+cat(':::\n::::\n')
+```
+
 | Description | Code | Output |
 |---|---|---|
 | Greek: alpha | `\a` | $\a$ |


### PR DESCRIPTION
## Problem

The CI **Render** step emits 10 `Could not convert TeX math` warnings (one per macro: `\a \b \g \l \s \llik \ind \siid \Normal \vm \hb`), all from the example table in `demo-include-in-header.qmd`:

```
[WARNING] Could not convert TeX math \a, rendering as TeX:
  unexpected control sequence \a
```

Cause: the `include-in-header` strategy loads macros into MathJax (HTML/RevealJS) and the LaTeX preamble (PDF) **at render time**, but pandoc's texmath pre-pass never sees them, so it can't convert the `$...$` examples (and falls back to raw TeX — harmless but noisy). This is inherent to the header method; `demo-shortcode.qmd` avoids it only because `{{< include >}}` puts the defs in the body where pandoc reads them.

These warnings pre-exist on `main` and are unrelated to #61.

## Fix

Emit the macro definitions once, hidden, as **bare `\def` lines in the document body**. Pandoc's `latex_macros` extension picks up body-level `\def` and applies it to subsequent math, so texmath converts the examples cleanly.

Key point — this does **not** turn the file into the shortcode demo: the bare `\def` lines are not `$...$` math, so **MathJax ignores them in the browser**. The visible examples still render via the include-in-header config; the hidden block only satisfies pandoc's server-side parser. It's wrapped in `content-hidden when-format="pdf"` (display:none is a no-op in PDF, which already resolves macros via the preamble).

## Verification

- Warning count **10 → 0** under a CI-faithful `quarto render ... --to html -M html-math-method:mathml` (and under docx).
- Hidden block stays inside a `display:none` container in the HTML output and is **absent** from the LaTeX output.
- Example math survives to both HTML (MathJax) and PDF (preamble) — the demo renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)