### PR TITLE
Add \hR macro for the Gelman–Rubin statistic

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -97,6 +97,7 @@
 \def\defeq{\stackrel{\text{def}}{=}}
 \def\hb{\hat \beta}
 \def\hvb{\hat{\vb}}
+\def\hR{\hat{R}}
 \def\hk{\hat \kappa}
 \def\hkappa{\hat \kappa}
 \def\hl{\hat \lambda}


### PR DESCRIPTION
Adds `\def\hR{\hat{R}}` next to the sibling hat macros (`\hb`, `\hvb`), so chapters can write `\hR` instead of raw `\hat{R}` for the Gelman–Rubin convergence statistic. Requested in rme PR #837 review (rounds 8–9).