### PR TITLE
Add interpretations.tsv entry for \hR (fixes red build-deploy)

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -98,6 +98,7 @@ name	interpretation
 \defeq	equals-by-definition (alias for \eqdef)
 \hb	estimated beta coefficient β̂
 \hvb	estimated beta vector (β̂-vector)
+\hR	Gelman-Rubin convergence diagnostic (potential scale reduction factor, R-hat)
 \hk	estimated kappa κ̂
 \hkappa	estimated kappa (alias for \hk)
 \hl	estimated lambda λ̂


### PR DESCRIPTION
## Summary

`macros`' `build-deploy` (Quarto render) has failed on **every push to `main` since 2026-06-08**, when [#63](https://github.com/d-morrison/macros/pull/63) added `\def\hR{\hat{R}}` to `macros.qmd` without a corresponding row in `interpretations.tsv`.

`macros-table.qmd`'s `parse-macros` chunk enforces that **every** macro defined in `macros.qmd` has an interpretation entry, and `stop()`s otherwise:

```
! Missing interpretation entries in interpretations.tsv for: \hR
Quitting from macros-table.qmd:43-164 [parse-macros]
```

This PR adds the one missing row, restoring a green build.

## Change

- `interpretations.tsv`: add a row for `\hR` — *"Gelman-Rubin convergence diagnostic (potential scale reduction factor, R-hat)"* — placed between `\hvb` and `\hk` to match the definition order in `macros.qmd`.

## Verification

Simulated the `parse-macros` check in a UTF-8 locale:

- 617 rows read from `interpretations.tsv`
- `\hR` present: **TRUE**
- Missing interpretation entries: **(none)**

## Context

Found while a separate docs PR ([#65](https://github.com/d-morrison/macros/pull/65), an ADR) inherited this same red CI. Kept as its own scoped PR rather than mixed into the docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrceBhXtcKRFaPPEMwxAZN)_