### PR TITLE
Render \Lik with \mathcal so it shows as a cursive L

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -140,7 +140,7 @@
 \def\simiid{\siid}
 \def\distiid{\siid}
 \def\tf{\therefore}
-\def\Lik{\mathscr{L}}
+\def\Lik{\mathcal{L}}
 \def\llik{\ell}
 \def\loglik{\ell}
 \def\logl{\ell}


### PR DESCRIPTION
## Problem

On the [Macro Reference table](https://d-morrison.github.io/macros/macros-table.html), the `\Lik` symbol in the **Example** column doesn't match the script ℒ shown in the **Interpretation** column.

## Cause

`\Lik` was the **only** macro defined with `\mathscr`:

```tex
\def\Lik{\mathscr{L}}
```

Every other script-style symbol in `macros.qmd` uses `\mathcal` — e.g. `\riskset = \mathcal{R}`, `\cR`, `\range`, `\Range`, `\einf`.

I confirmed the rendering difference with MathJax 3.2.1 (the version Quarto uses):

| Input | Codepoint | MathJax font variant |
|---|---|---|
| `\mathscr{L}` | U+2112 | `mjx-sc` / `TEX-SC` → **MathJax_Script** (ornate swirly cursive) |
| `\mathcal{L}` | U+004C | `mjx-cal` / `TEX-C` → **MathJax_Caligraphic** (standard 𝓛) |

So `\mathscr{L}` was being drawn in MathJax's ornate Script font, which looks different from both the conventional calligraphic likelihood symbol 𝓛 and the plain ℒ (U+2112) that the Interpretation column shows in the page's body font.

## Fix

```tex
\def\Lik{\mathcal{L}}
```

This renders `\Lik` as the conventional likelihood symbol 𝓛 using the always-available calligraphic font, and makes it consistent with every other script-letter macro in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWQtQtqMJQuFyGMpLE5UYU)_