### PR TITLE
fix: use \def instead of \providecommand for \v macro

### DIFF
--- a/macros.qmd
+++ b/macros.qmd
@@ -336,7 +336,7 @@
 \providecommand{\erf}[1]{\err\paren{#1}}
 \renewcommand{\vec}[1]{\tilde{#1}}
 \providecommand{\vecf}[1]{\tilde{#1}}
-\providecommand{\v}[1]{\vecf{#1}}
+\def\v#1{\vecf{#1}}
 \providecommand{\matr}[1]{\mathbf{#1}}
 \def\mX{\matr{X}}
 \def\mx{\matr{x}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -336,7 +336,7 @@
 \providecommand{\erf}[1]{\err\paren{#1}}
 \renewcommand{\vec}[1]{\tilde{#1}}
 \providecommand{\vecf}[1]{\tilde{#1}}
-\def\v#1{\vecf{#1}}
+\renewcommand{\v}[1]{\vecf{#1}}
 \providecommand{\matr}[1]{\mathbf{#1}}
 \def\mX{\matr{X}}
 \def\mx{\matr{x}}


### PR DESCRIPTION
## Summary

- `\providecommand{\v}[1]{\vecf{#1}}` was a silent no-op because `\v` is a LaTeX built-in (the caron text accent). `\providecommand` only defines a command if it doesn't already exist, so `\v` kept its built-in meaning and never became a tilde-vector.
- Replace with `\def\v#1{\vecf{#1}}`, which always overrides — the same pattern already used for `\vec` (`\renewcommand`) and other single-letter macros (`\def`).
- Audited all other `\providecommand` definitions with single-letter names; `\v` was the only one shadowing a LaTeX built-in text accent.

Fixes d-morrison/rme#950.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tk6Sptjt197fF7XBn3QFp7)_