### PR TITLE
feat: add likelihood-function, estimated-CDF, and potential/observed-outcome macros

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -475,6 +475,9 @@ name	interpretation
 \pdf	probability density function symbol f
 \pmf	probability mass function P(·)
 \cdf	cumulative distribution function symbol F
+\cdff	cumulative distribution function F(·) applied to argument
+\hcdf	estimated cumulative distribution function F̂
+\hcdff	estimated cumulative distribution function F̂(·) applied to argument
 \defLik	definitional expression for likelihood ℒ(θ)
 \defLogLik	definitional expression for log-likelihood ℓ
 \defScore	definitional expression for score function ℓ′

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -146,6 +146,10 @@ name	interpretation
 \loglik	log-likelihood symbol (alias for \llik)
 \logl	log-likelihood symbol (alias for \llik)
 \llikf	log-likelihood function ℓ(·)
+\Likf	likelihood function ℒ(·)
+\loglikf	log-likelihood function ℓ(·) (alias for \llikf)
+\loglf	log-likelihood function ℓ(·) (alias for \llikf)
+\likf	log-likelihood function ℓ(·) (alias for \llikf)
 \deviation	deviation symbol e
 \devn	deviation symbol (alias for \deviation)
 \deviationv	deviation vector ẽ

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -420,6 +420,11 @@ name	interpretation
 \probs	probability symbol (alias for \prob)
 \risk	risk symbol π (used as the subscript for \riskratio)
 \prev	prevalence symbol π (used as the subscript for \prevratio)
+\potout	potential outcome Y_a (outcome under intervened exposure a)
+\potprob	potential outcome probability π_a (e.g. Pr(Y_a=1) for binary Y)
+\potmean	potential outcome mean μ_a (e.g. E[Y_a])
+\obsprob	observed outcome probability π(a) (given observed exposure a)
+\obsmean	observed outcome mean μ(a) (given observed exposure a)
 \probit	probit link function
 \oddsf	odds function odds{·}
 \doddsf	derivative of odds function odds′{·}

--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -425,6 +425,11 @@ name	interpretation
 \potmean	potential outcome mean μ_a (e.g. E[Y_a])
 \obsprob	observed outcome probability π(a) (given observed exposure a)
 \obsmean	observed outcome mean μ(a) (given observed exposure a)
+\py	potential outcome Y_a (shorthand for \potout)
+\ppi	potential outcome probability π_a (shorthand for \potprob)
+\pmu	potential outcome mean μ_a (shorthand for \potmean)
+\opi	observed outcome probability π(a) (shorthand for \obsprob)
+\omu	observed outcome mean μ(a) (shorthand for \obsmean)
 \probit	probit link function
 \oddsf	odds function odds{·}
 \doddsf	derivative of odds function odds′{·}

--- a/macros.qmd
+++ b/macros.qmd
@@ -511,6 +511,9 @@
 \def\pdf{\distop{f}}
 \providecommand{\pmf}[1]{\distop{P}\paren{#1}}
 \def\cdf{\distop{F}}
+\providecommand{\cdff}[1]{\cdf\paren{#1}}
+\def\hcdf{\mathop{\hat{\cdf}}\nolimits}
+\providecommand{\hcdff}[1]{\hcdf\paren{#1}}
 \def\defLik{\Lik(\theta) \eqdef \p(\vX = \vx | \Theta = \theta)}
 \def\defLogLik{\lik \eqdef \logf{\Lik(\vx|\th)}}
 \def\defScore{\score \eqdef \deriv{\th} \lik(\vx|\th)}

--- a/macros.qmd
+++ b/macros.qmd
@@ -423,6 +423,11 @@
 \providecommand{\potmean}[1]{\mean_{#1}}
 \providecommand{\obsprob}[1]{\prob\paren{#1}}
 \providecommand{\obsmean}[1]{\mean\paren{#1}}
+\def\py{\potout}
+\def\ppi{\potprob}
+\def\pmu{\potmean}
+\def\opi{\obsprob}
+\def\omu{\obsmean}
 \def\probit{\operatorname{probit}}
 \providecommand{\oddsf}[1]{\oddst\cb{#1}}
 \providecommand{\doddsf}[1]{{\oddst}'\cb{#1}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -145,6 +145,10 @@
 \def\loglik{\ell}
 \def\logl{\ell}
 \providecommand{\llikf}[1]{\llik \paren{#1}}
+\providecommand{\Likf}[1]{\Lik\paren{#1}}
+\def\loglikf{\llikf}
+\def\loglf{\llikf}
+\def\likf{\llikf}
 \def\deviation{e}
 \def\devn{\deviation}
 \providecommand{\deviationv}{\vec{\deviation}}

--- a/macros.qmd
+++ b/macros.qmd
@@ -418,6 +418,11 @@
 \def\probs{\pi}
 \def\risk{\pi}
 \def\prev{\pi}
+\providecommand{\potout}[1]{Y_{#1}}
+\providecommand{\potprob}[1]{\prob_{#1}}
+\providecommand{\potmean}[1]{\mean_{#1}}
+\providecommand{\obsprob}[1]{\prob\paren{#1}}
+\providecommand{\obsmean}[1]{\mean\paren{#1}}
 \def\probit{\operatorname{probit}}
 \providecommand{\oddsf}[1]{\oddst\cb{#1}}
 \providecommand{\doddsf}[1]{{\oddst}'\cb{#1}}


### PR DESCRIPTION
Clears the open-issue backlog (issue **#56 intentionally left out of scope**). Each issue is a separate commit; every new macro has a matching `interpretations.tsv` entry, so the `macros-table.qmd` build still passes.

## #64 — likelihood / log-likelihood function forms

| Macro | Expands to | Meaning |
|---|---|---|
| `\Likf{x}` | `\Lik(x)` | likelihood function, ℒ(·) |
| `\loglikf{x}` | `\llik(x)` | log-likelihood function, ℓ(·) (alias of `\llikf`) |
| `\loglf{x}` | `\llik(x)` | log-likelihood function (alias of `\llikf`) |
| `\likf{x}` | `\llik(x)` | log-likelihood function (alias of `\llikf`) |

Completes the function-form family for the existing `\Lik` / `\llik` symbols. The lowercase-`\lik`-means-log-likelihood convention is pre-existing (`\lik` is already an alias of `\llik`); the TSV entries flag each alias accordingly.

## #69 — estimated CDF function macros

| Macro | Expands to | Meaning |
|---|---|---|
| `\cdff{x}` | `\cdf(x)` | CDF applied to argument, F(·) |
| `\hcdf` | `F̂` | estimated CDF symbol |
| `\hcdff{x}` | `\hcdf(x)` | estimated CDF applied to argument, F̂(·) |

Mirrors the existing `\Q`/`\Qf`/`\hQ`/`\hQf` and `\surv`/`\survf`/`\hsurv`/`\hSurvf` distribution-function families; `\hcdf` uses the same `\mathop{\hat{…}}\nolimits` pattern as `\hsurv`.

## #70 — potential-outcome vs observed-outcome notation

Following the convention in the issue — **subscripts for potential (intervened) exposures, parentheses for observed exposures**:

| Macro | Expands to | Meaning |
|---|---|---|
| `\potout{a}` | Y_a | potential outcome under exposure `a` |
| `\potprob{a}` | π_a | potential outcome probability (e.g. Pr(Y_a = 1) for binary Y) |
| `\potmean{a}` | μ_a | potential outcome mean (e.g. E[Y_a]) |
| `\obsprob{a}` | π(a) | observed outcome probability |
| `\obsmean{a}` | μ(a) | observed outcome mean |

These reuse the existing `\prob` (π) and `\mean` (μ) symbols, so they are notation variants of existing estimands rather than a new estimand group, and need no separate hat-wrapped estimators.

## Verification

- Replicated the `macros-table.qmd` build check: every new macro has an `interpretations.tsv` entry (no missing/orphan entries; no name collisions).
- Loaded the full `macros.qmd` into a lualatex preamble and rendered every new macro to PDF — all produce the intended symbols (ℒ(θ), ℓ(θ), F(x), F̂, F̂(x), Y_a, π_a, μ_a, π(a), μ(a)).
- Re-rendered `demo-shortcode.qmd` to PDF to confirm the include-shortcode path still loads `macros.qmd` cleanly.

Full HTML render via CI (`Quarto Preview`), since `DT`/`knitr` aren't installable against the container's bleeding-edge R.

Closes #64
Closes #69
Closes #70

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dv2xDZnATLy84rCSUzrSn)_