### PR TITLE
Add \seq macro for tight R-style colon ranges

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -190,6 +190,7 @@ name	interpretation
 \range	range / codomain (alias for \cR)
 \Range	range / codomain (alias for \cR)
 \rangef	range of a function ℛ(·)
+\seq	sequence (colon range) from first to second argument, e.g. 1:n
 \~	approximately equal (≈)
 \dapp	approximately equal dot notation (≐)
 \deriv	partial derivative operator ∂/∂(·)

--- a/macros.qmd
+++ b/macros.qmd
@@ -188,6 +188,7 @@
 \def\range{\mathcal{R}}
 \def\Range{\mathcal{R}}
 \providecommand{\rangef}[1]{\cR(#1)}
+\providecommand{\seq}[2]{#1{:}#2}
 \def\~{\approx}
 \def\dapp{\dot\approx}
 \providecommand{\deriv}[1]{\frac{\partial}{\partial #1}}


### PR DESCRIPTION
## Summary

Adds a `\seq` macro so index sets can render a tight, unspaced colon range like `1:n` instead of the spaced binary-relation that a bare `:` produces in math mode.

- `macros.qmd`: `\providecommand{\seq}[2]{#1{:}#2}`, placed next to the range macros (`\range`/`\rangef`). No comment added — `macros.qmd` stays a flat, comment-free definition list per CONTRIBUTING.md.
- `interpretations.tsv`: matching row (required — the `macros-table.qmd` build fails on any macro lacking an interpretation).

## Usage

`$i \in \set{\seq{1}{n}}$` renders `i ∈ {1:n}` with a tight colon.

## Testing

The bcs conda R env here lacks knitr/rmarkdown, so a full `quarto render` can't run locally — CI (preview/publish) covers it. I did validate the exact R parsing logic from `macros-table.qmd` against the edited files: all 638 macros parse and none are missing an interpretation, and `\seq` parses to 2 args with its interpretation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)