### PR TITLE
Add \argmin macro (counterpart to existing \argmax)

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -11,6 +11,8 @@ name	interpretation
 \Prf	Pr(·) probability expression
 \am	arg max operator
 \argmax	arg max operator (alias for \am)
+\amin	arg min operator
+\argmin	arg min operator (alias for \amin)
 \p	probability density/mass function symbol p
 \f	probability density function symbol f
 \F	cumulative distribution function symbol F

--- a/macros.qmd
+++ b/macros.qmd
@@ -10,6 +10,8 @@
 \providecommand{\Prf}[1]{\Pr\paren{#1}}
 \def\am{\arg \max}
 \def\argmax{\arg \max}
+\def\amin{\arg \min}
+\def\argmin{\arg \min}
 \def\p{\distop{p}}
 \def\f{\distop{f}}
 \def\F{\distop{F}}


### PR DESCRIPTION
Closes #73

Adds `\argmin` (and `\amin` short alias), the missing counterpart to the existing `\am`/`\argmax`. This is a general-purpose operator used across optimization, estimation, and statistics generally — not tied to any one estimand family — so it sits alongside `\argmax` rather than in a narrower macro group.

## Change

```
\def\amin{\arg \min}
\def\argmin{\arg \min}
```

Plus matching `interpretations.tsv` entries, per `CONTRIBUTING.md`.

## Verification

Ran all three commands `CONTRIBUTING.md` documents before pushing changes to `macros.qmd` (installed `knitr`/`rmarkdown`/`DT` + TinyTeX locally to do this for real, since CI's "Quarto Preview" workflow only runs a default `quarto render`, which doesn't cover the two PDF-specific commands):

- `quarto render demo-include-in-header.qmd --to pdf` — succeeds, `_site/demo-include-in-header.pdf` produced
- `quarto render demo-shortcode.qmd --to pdf` — succeeds, `_site/demo-shortcode.pdf` produced
- `quarto render` (whole site) — succeeds, including `macros-table.qmd`'s interpretations-consistency check (640 macros parsed, zero missing `interpretations.tsv` entries); `\amin`/`\argmin` both appear correctly in the built macro reference table

No new macro-name collisions (the only duplicate names in the corpus — `\resid`, `\stdresid`, `\modresid` — are pre-existing and unrelated to this change).