### PR TITLE
Add survival-function estimator macros (empirical, KM, Nelson-Aalen)

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -636,3 +636,12 @@ name	interpretation
 \hfsurv	estimated survival factor (alias for \hsurvfactor)
 \hfsurvf	estimated survival factor function (alias for \hsurvfactorf)
 \hsurvff	estimated survival factor function (shorthand for \hsurvfactorf)
+\emp	empirical estimator label ("emp" subscript)
+\km	Kaplan-Meier estimator label ("KM" subscript)
+\naa	Nelson-Aalen estimator label ("NA" subscript)
+\hsurvemp	empirical survival function estimator Ŝ_emp
+\hsurvkm	Kaplan-Meier survival function estimator Ŝ_KM
+\hsurvnaa	Nelson-Aalen survival function estimator Ŝ_NA
+\hsurvempf	empirical survival function estimator Ŝ_emp(·) applied to argument
+\hsurvkmf	Kaplan-Meier survival function estimator Ŝ_KM(·) applied to argument
+\hsurvnaaf	Nelson-Aalen survival function estimator Ŝ_NA(·) applied to argument

--- a/macros.qmd
+++ b/macros.qmd
@@ -114,6 +114,15 @@
 \def\hsurv{\mathop{\hat{\surv}}\nolimits}
 \def\hSurv{\mathop{\hat{\surv}}\nolimits}
 \providecommand{\hSurvf}[1]{\hSurv\paren{#1}}
+\def\emp{\text{emp}}
+\def\km{\text{KM}}
+\def\naa{\text{NA}}
+\def\hsurvemp{\hsurv_{\emp}}
+\def\hsurvkm{\hsurv_{\km}}
+\def\hsurvnaa{\hsurv_{\naa}}
+\providecommand{\hsurvempf}[1]{\hsurvemp\paren{#1}}
+\providecommand{\hsurvkmf}[1]{\hsurvkm\paren{#1}}
+\providecommand{\hsurvnaaf}[1]{\hsurvnaa\paren{#1}}
 \def\dist{\ \sim \ }
 \def\ddist{\ \dot{\sim} \ }
 \def\dsim{\ \dot{\sim} \ }


### PR DESCRIPTION
## Summary
- Closes #75.
- Adds `\emp`, `\km`, `\naa` as small composable subscript-label macros for the empirical, Kaplan-Meier, and Nelson-Aalen estimator names.
- Composes them onto the existing `\hsurv` (hat-S) macro to define `\hsurvemp`, `\hsurvkm`, `\hsurvnaa`, so the hat lands only over `S` and the estimator name appears as a subscript (e.g. `\hsurvkm` renders as $\hat{S}_{\text{KM}}$), matching the example in the issue.
- Adds the one-argument function-call variants `\hsurvempf`, `\hsurvkmf`, `\hsurvnaaf` (e.g. `\hsurvkmf{t}` → $\hat{S}_{\text{KM}}(t)$), following the existing `\hSurvf` pattern.
- Adds matching entries to `interpretations.tsv` for all nine new macros (required by `macros-table.qmd`'s build-time completeness check).

## Notes
- Placed the new macros right after the existing `\hsurv`/`\hSurv`/`\hSurvf` block in `macros.qmd`, since that's the natural home for hat-S-estimator macros.
- Did not reuse the existing `\NA` macro (already means "not-available" placeholder) for the Nelson-Aalen label — `\naa` is a distinct, case-sensitive command name, so there's no collision.
- Did not define un-hatted "population" versions (e.g. `\survkm`) since KM/NA/empirical are inherently sample-based estimators, not estimands.

## Test plan
- [x] Verified `interpretations.tsv` has no missing entries for any macro in `macros.qmd` (replicated the `macros-table.qmd` completeness check via a standalone R script, since this sandbox's R installation is missing `rmarkdown`/`sass` build tooling and couldn't run a full `quarto render`).
- [x] Verified brace-balance / syntax of all new `\def`/`\providecommand` lines.
- [ ] Full `quarto render` of `macros-table.qmd`, `demo-include-in-header.qmd --to pdf`, and `demo-shortcode.qmd --to pdf` per `CONTRIBUTING.md` — **not run**, this sandbox lacks a working R/LaTeX toolchain (rmarkdown's `sass` dependency fails to build, no `pdflatex`). Recommend a maintainer or CI run these before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aft1cX4n2fqvcE2tsW44gp)_