### PR TITLE
Shorten survival-estimator macro names (hsurvkmf -> hskmf, etc.)

### DIFF
--- a/interpretations.tsv
+++ b/interpretations.tsv
@@ -639,9 +639,9 @@ name	interpretation
 \emp	empirical estimator label ("emp" subscript)
 \km	Kaplan-Meier estimator label ("KM" subscript)
 \naa	Nelson-Aalen estimator label ("NA" subscript)
-\hsurvemp	empirical survival function estimator Ŝ_emp
-\hsurvkm	Kaplan-Meier survival function estimator Ŝ_KM
-\hsurvnaa	Nelson-Aalen survival function estimator Ŝ_NA
-\hsurvempf	empirical survival function estimator Ŝ_emp(·) applied to argument
-\hsurvkmf	Kaplan-Meier survival function estimator Ŝ_KM(·) applied to argument
-\hsurvnaaf	Nelson-Aalen survival function estimator Ŝ_NA(·) applied to argument
+\hsemp	empirical survival function estimator Ŝ_emp
+\hskm	Kaplan-Meier survival function estimator Ŝ_KM
+\hsnaa	Nelson-Aalen survival function estimator Ŝ_NA
+\hsempf	empirical survival function estimator Ŝ_emp(·) applied to argument
+\hskmf	Kaplan-Meier survival function estimator Ŝ_KM(·) applied to argument
+\hsnaaf	Nelson-Aalen survival function estimator Ŝ_NA(·) applied to argument

--- a/macros.qmd
+++ b/macros.qmd
@@ -117,12 +117,12 @@
 \def\emp{\text{emp}}
 \def\km{\text{KM}}
 \def\naa{\text{NA}}
-\def\hsurvemp{\hsurv_{\emp}}
-\def\hsurvkm{\hsurv_{\km}}
-\def\hsurvnaa{\hsurv_{\naa}}
-\providecommand{\hsurvempf}[1]{\hsurvemp\paren{#1}}
-\providecommand{\hsurvkmf}[1]{\hsurvkm\paren{#1}}
-\providecommand{\hsurvnaaf}[1]{\hsurvnaa\paren{#1}}
+\def\hsemp{\hsurv_{\emp}}
+\def\hskm{\hsurv_{\km}}
+\def\hsnaa{\hsurv_{\naa}}
+\providecommand{\hsempf}[1]{\hsemp\paren{#1}}
+\providecommand{\hskmf}[1]{\hskm\paren{#1}}
+\providecommand{\hsnaaf}[1]{\hsnaa\paren{#1}}
 \def\dist{\ \sim \ }
 \def\ddist{\ \dot{\sim} \ }
 \def\dsim{\ \dot{\sim} \ }


### PR DESCRIPTION
## Summary
- Follow-up to [#76](https://github.com/d-morrison/macros/pull/76) (issue #75): shortens the survival-estimator macro names per request.
- Renames `\hsurvemp`/`\hsurvkm`/`\hsurvnaa` (and their `f`-suffixed function-call forms) to `\hsemp`/`\hskm`/`\hsnaa`.
- Updates the matching `interpretations.tsv` entries. Pure rename — no change in semantics or composition (still built on the existing `\hsurv` hat-S macro).

## Test plan
- [x] Verified no missing/duplicate `interpretations.tsv` entries via the same standalone R check used in #76.
- [x] Verified the diff is a clean 1:1 rename (no other lines touched).
- [ ] Full `quarto render` — not run locally (same sandbox limitation as #76); relying on this repo's `build-deploy` CI (which renders the whole site + both PDF demos) to validate, as it did for #76.

This is a rename-only change; downstream PRs [d-morrison/rme#978](https://github.com/d-morrison/rme/pull/978) and [ucdavis/epi204#358](https://github.com/ucdavis/epi204/pull/358) will be updated to use the new names once this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aft1cX4n2fqvcE2tsW44gp)_